### PR TITLE
update pytest-asyncio version to fix builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ python = "^2.7 || ^3.4"
 flake8 = "^3.6"
 pytest = "^4.0"
 pytest-cov = "^2.6"
-pytest-asyncio = {version = "^0.9.0",python = "^3.5"}
+pytest-asyncio = {version = "^0.10.0",python = "^3.5"}
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
update to pytest-asyncio 0.10.0 to fix builds

https://stackoverflow.com/questions/54064971/importerror-cannot-import-name-transfer-markers-when-testing-with-pytest